### PR TITLE
Enhance toHaveTool error message to list available tools

### DIFF
--- a/src/matchers/__tests__/toHaveTool.test.ts
+++ b/src/matchers/__tests__/toHaveTool.test.ts
@@ -34,13 +34,38 @@ describe('toHaveTool', () => {
   it('should fail when MCP server does not have the tool', async () => {
     const mockMCPServer = Object.create(MCPStdinSubprocess.prototype);
     mockMCPServer.hasTool = vi.fn().mockResolvedValue(false);
+    mockMCPServer.getTools = vi.fn().mockResolvedValue([
+      { name: 'tool1' },
+      { name: 'tool2' },
+      { name: 'tool3' },
+    ]);
 
     const result = await toHaveTool.call(mockContext, mockMCPServer, 'nonExistentTool');
 
     expect(result.pass).toBe(false);
     expect(result.message()).toContain('Expected MCP server to have tool');
     expect(result.message()).toContain('nonExistentTool');
+    expect(result.message()).toContain('Available tools:');
+    expect(result.message()).toContain('tool1');
+    expect(result.message()).toContain('tool2');
+    expect(result.message()).toContain('tool3');
     expect(mockMCPServer.hasTool).toHaveBeenCalledWith('nonExistentTool');
+    expect(mockMCPServer.getTools).toHaveBeenCalled();
+  });
+
+  it('should fail when MCP server has no tools available', async () => {
+    const mockMCPServer = Object.create(MCPStdinSubprocess.prototype);
+    mockMCPServer.hasTool = vi.fn().mockResolvedValue(false);
+    mockMCPServer.getTools = vi.fn().mockResolvedValue([]);
+
+    const result = await toHaveTool.call(mockContext, mockMCPServer, 'anyTool');
+
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain('Expected MCP server to have tool');
+    expect(result.message()).toContain('anyTool');
+    expect(result.message()).toContain('No tools are available from this server');
+    expect(mockMCPServer.hasTool).toHaveBeenCalledWith('anyTool');
+    expect(mockMCPServer.getTools).toHaveBeenCalled();
   });
 
   it('should fail when received is not an MCPStdinSubprocess instance', async () => {


### PR DESCRIPTION
## Summary

- Enhanced the `toHaveTool` matcher to display available tools when a tool is not found
- Added comprehensive test coverage for the new error message format

## Details

When `toHaveTool` fails because a tool is not found, the error message now includes a list of all available tools from the MCP server. This significantly improves the debugging experience by:

1. Helping developers quickly identify typos in tool names
2. Showing what tools are actually available from the server
3. Making it clear when a server has no tools exposed

### Example Error Messages

**Before:**
```
Expected MCP server to have tool "getTodo", but it doesn't
```

**After (when tools are available):**
```
Expected MCP server to have tool "getTodo", but it doesn't

Available tools: "add_todo", "delete_todo", "list_todos"
```

**After (when no tools are available):**
```
Expected MCP server to have tool "anyTool", but it doesn't

No tools are available from this server
```

## Test Plan

- [x] Added unit tests for error message with available tools
- [x] Added unit tests for error message with no tools
- [x] All existing tests pass
- [x] Build succeeds