### PR TITLE
Add ToolCallResult class with helper methods and matchers

### DIFF
--- a/docs-site/docs/ReadResourceResult.md
+++ b/docs-site/docs/ReadResourceResult.md
@@ -1,0 +1,186 @@
+# ReadResourceResult
+
+The `ReadResourceResult` class wraps the result of a resource read with helper methods for accessing content.
+
+When you call `app.readResource()`, it returns a `ReadResourceResult` instance instead of a raw response object.
+
+## Properties
+
+### `raw`
+
+Get the raw result object.
+
+```ts
+const result = await app.readResource('file:///app/config.json');
+const rawResult = result.raw;
+// rawResult is the ReadResourceResult object
+```
+
+### `contents`
+
+Get the contents array containing all resources returned.
+
+```ts
+const result = await app.readResource('file:///app/test.txt');
+const contents = result.contents;
+// contents is an array of TextResourceContents or BlobResourceContents objects
+```
+
+## Methods
+
+### `getTextContent()`
+
+Get the text content from the first text resource in the contents array.
+
+Returns `string | undefined` - The text content, or `undefined` if no text resources exist.
+
+```ts
+const result = await app.readResource('file:///app/test.txt');
+const text = result.getTextContent();
+// Returns the file contents as a string
+```
+
+### `getBlobContent()`
+
+Get the blob content (base64-encoded) from the first blob resource in the contents array.
+
+Returns `string | undefined` - The blob content, or `undefined` if no blob resources exist.
+
+```ts
+const result = await app.readResource('file:///app/image.png');
+const blob = result.getBlobContent();
+// Returns the base64-encoded image data
+```
+
+### `findByUri(uri)`
+
+Find a resource by its URI.
+
+**Parameters:**
+- `uri`: The URI of the resource to find
+
+**Returns:** The resource with the matching URI, or `undefined`.
+
+```ts
+const result = await app.readResource('file:///app/test.txt');
+const resource = result.findByUri('file:///app/test.txt');
+if (resource && 'text' in resource) {
+  console.log('Text:', resource.text);
+}
+```
+
+### `getAllTextResources()`
+
+Get all text resources from the contents array.
+
+**Returns:** An array of text resources.
+
+```ts
+const result = await app.readResource('file:///app/data');
+const textResources = result.getAllTextResources();
+textResources.forEach(resource => {
+  console.log(`${resource.uri}: ${resource.text}`);
+});
+```
+
+### `getAllBlobResources()`
+
+Get all blob resources from the contents array.
+
+**Returns:** An array of blob resources.
+
+```ts
+const result = await app.readResource('file:///app/images');
+const blobResources = result.getAllBlobResources();
+blobResources.forEach(resource => {
+  console.log(`${resource.uri}: ${resource.mimeType}`);
+});
+```
+
+### `hasTextContent()`
+
+Check if the result contains any text resources.
+
+**Returns:** `true` if at least one text resource exists.
+
+```ts
+const result = await app.readResource('file:///app/test.txt');
+if (result.hasTextContent()) {
+  console.log('Has text:', result.getTextContent());
+}
+```
+
+### `hasBlobContent()`
+
+Check if the result contains any blob resources.
+
+**Returns:** `true` if at least one blob resource exists.
+
+```ts
+const result = await app.readResource('file:///app/image.png');
+if (result.hasBlobContent()) {
+  console.log('Has blob data');
+}
+```
+
+## Complete Example
+
+```ts
+import { mcpShell } from 'expect-mcp';
+import { test, expect } from 'vitest';
+
+test('read resource with ReadResourceResult', async () => {
+  const app = mcpShell('node file-server.js');
+  await app.initialize();
+
+  // Read a text file
+  const textResult = await app.readResource('file:///tmp/test.txt');
+
+  // Use helper methods
+  const text = textResult.getTextContent();
+  expect(text).toBeDefined();
+
+  // Or use matchers
+  await expect(textResult).toHaveResourceContent('file:///tmp/test.txt');
+  await expect(textResult).toHaveTextResource('Hello world');
+
+  // Read an image file
+  const imageResult = await app.readResource('file:///tmp/image.png');
+  const blob = imageResult.getBlobContent();
+  expect(blob).toBeDefined();
+  expect(imageResult.hasBlobContent()).toBe(true);
+
+  // Find by URI
+  const resource = textResult.findByUri('file:///tmp/test.txt');
+  expect(resource).toBeDefined();
+  expect(resource?.uri).toBe('file:///tmp/test.txt');
+
+  await app.close();
+});
+```
+
+## Resource Metadata
+
+Resources may include additional metadata fields:
+
+```ts
+const result = await app.readResource('file:///app/config.json');
+const resource = result.contents[0];
+
+console.log('URI:', resource.uri);
+console.log('Name:', resource.name);  // Optional
+console.log('Title:', resource.title);  // Optional
+console.log('MIME Type:', resource.mimeType);  // Optional
+
+// Annotations (optional)
+if (resource.annotations) {
+  console.log('Audience:', resource.annotations.audience);  // ['user', 'assistant']
+  console.log('Priority:', resource.annotations.priority);  // 0.0 to 1.0
+  console.log('Last Modified:', resource.annotations.lastModified);  // ISO 8601 timestamp
+}
+```
+
+## See Also
+
+- [readResource](readResource) - Read a resource from an MCP server
+- [Matchers](matchers) - Custom matchers for testing resource results

--- a/docs-site/docs/ToolCallResult.md
+++ b/docs-site/docs/ToolCallResult.md
@@ -1,0 +1,155 @@
+# ToolCallResult
+
+The `ToolCallResult` class wraps the result of a tool call with helper methods for accessing content and validating success.
+
+When you call `app.callTool()`, it returns a `ToolCallResult` instance instead of a raw response object.
+
+## Properties
+
+### `raw`
+
+Get the raw result object.
+
+```ts
+const result = await app.callTool('read_file', { path: '/app/test.txt' });
+const rawResult = result.raw;
+// rawResult is the CallToolResult object
+```
+
+### `content`
+
+Get the content array containing all content blocks returned by the tool.
+
+```ts
+const result = await app.callTool('read_file', { path: '/app/test.txt' });
+const contentBlocks = result.content;
+// contentBlocks is an array of ContentBlock objects
+```
+
+### `structuredContent`
+
+Get the structured content if present. This is an optional field that may be returned by tools that support structured output.
+
+```ts
+const result = await app.callTool('get_weather', { location: 'New York' });
+const data = result.structuredContent;
+// data might be { temperature: 72, conditions: 'sunny' }
+```
+
+### `isError`
+
+Check if the result represents an error.
+
+```ts
+const result = await app.callTool('write_file', { path: '/app/test.txt', content: 'Hello' });
+if (result.isError) {
+  console.log('Tool call failed');
+}
+```
+
+## Methods
+
+### `getTextContent()`
+
+Get the text content from the first text content block.
+
+Returns `string | undefined` - The text content, or `undefined` if no text content blocks exist.
+
+```ts
+const result = await app.callTool('read_file', { path: '/app/test.txt' });
+const text = result.getTextContent();
+// Returns the file contents as a string
+```
+
+### `expectSuccess()`
+
+Assert that the result is not an error. Throws a `ToolCallError` if the result has `isError` set to `true`.
+
+Returns the `ToolCallResult` instance for chaining.
+
+```ts
+const result = await app.callTool('write_file', {
+  path: '/app/test.txt',
+  content: 'Hello world'
+});
+result.expectSuccess(); // Throws if isError is true
+```
+
+Example with chaining:
+
+```ts
+const text = await app.callTool('read_file', { path: '/app/test.txt' })
+  .then(result => result.expectSuccess())
+  .then(result => result.getTextContent());
+```
+
+### `getContentByType(type)`
+
+Get all content blocks of a specific type.
+
+**Parameters:**
+- `type`: The type of content blocks to retrieve (`'text'`, `'image'`, `'audio'`, `'resource_link'`, or `'resource'`)
+
+**Returns:** An array of content blocks matching the specified type.
+
+```ts
+const result = await app.callTool('generate_images', { prompt: 'cat' });
+const imageBlocks = result.getContentByType('image');
+// Returns all image content blocks
+```
+
+### `findContentByType(type)`
+
+Find the first content block of a specific type.
+
+**Parameters:**
+- `type`: The type of content block to find (`'text'`, `'image'`, `'audio'`, `'resource_link'`, or `'resource'`)
+
+**Returns:** The first content block of the specified type, or `undefined` if not found.
+
+```ts
+const result = await app.callTool('analyze_file', { path: '/app/image.png' });
+const imageBlock = result.findContentByType('image');
+if (imageBlock) {
+  console.log('Image MIME type:', imageBlock.mimeType);
+}
+```
+
+## Complete Example
+
+```ts
+import { mcpShell } from 'expect-mcp';
+import { test, expect } from 'vitest';
+
+test('read and write file with ToolCallResult', async () => {
+  const app = mcpShell('node file-server.js');
+  await app.initialize();
+
+  // Write a file and ensure it succeeded
+  const writeResult = await app.callTool('write_file', {
+    path: '/tmp/test.txt',
+    content: 'Hello world'
+  });
+  writeResult.expectSuccess();
+
+  // Read the file back
+  const readResult = await app.callTool('read_file', {
+    path: '/tmp/test.txt'
+  });
+
+  // Use the helper method to get text content
+  const content = readResult.getTextContent();
+  expect(content).toBe('Hello world');
+
+  // Or use the new matchers
+  await expect(readResult).toBeSuccessful();
+  await expect(readResult).toHaveTextContent('Hello world');
+
+  await app.close();
+});
+```
+
+## See Also
+
+- [callTool](callTool) - Call a tool on an MCP server
+- [Matchers](matchers) - Custom matchers for testing tool results

--- a/docs-site/docs/callTool.md
+++ b/docs-site/docs/callTool.md
@@ -10,7 +10,7 @@ Will throw an error if:
 ## Syntax
 
 ```ts
-app.callTool(name: string, arguments?: any): Promise<any>
+app.callTool(name: string, arguments?: any): Promise<ToolCallResult>
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ app.callTool(name: string, arguments?: any): Promise<any>
 
 ## Returns
 
-A Promise that resolves to the tool's response.
+A Promise that resolves to a [`ToolCallResult`](ToolCallResult) instance containing the tool's response.
 
 ## Example
 
@@ -37,8 +37,16 @@ test('call a tool on the server', async () => {
     path: '/path/to/file.txt',
   });
 
+  // result is a ToolCallResult instance
   expect(result).toBeDefined();
   expect(result.content).toBeDefined();
+
+  // Use helper methods
+  const text = result.getTextContent();
+  expect(text).toBeDefined();
+
+  // Or use matchers
+  await expect(result).toBeSuccessful();
 
   await app.close();
 });
@@ -58,5 +66,7 @@ const result = await app.callTool('slow_operation', {});
 
 ## See Also
 
+- [ToolCallResult](ToolCallResult) - The class returned by callTool
 - [mcpShell](mcpShell) - Create an MCP subprocess
 - [toHaveTool](toHaveTool) - Assert that a tool exists
+- [Matchers](matchers) - Custom matchers for validating tool results

--- a/docs-site/docs/matchers.md
+++ b/docs-site/docs/matchers.md
@@ -2,6 +2,78 @@
 
 The expect-mcp library provides custom Vitest matchers specifically designed for testing Model Context Protocol (MCP) integrations.
 
+## Tool Result Matchers
+
+These matchers work with `ToolCallResult` instances returned by `app.callTool()`.
+
+### toBeSuccessful()
+
+Checks that a tool call result is successful (does not have `isError` set to `true`).
+
+```ts
+const result = await app.callTool('write_file', {
+  path: '/tmp/test.txt',
+  content: 'Hello'
+});
+await expect(result).toBeSuccessful();
+```
+
+### toHaveTextContent(expectedText: string)
+
+Checks that a tool call result contains text content matching the expected string exactly.
+
+```ts
+const result = await app.callTool('read_file', {
+  path: '/tmp/test.txt'
+});
+await expect(result).toHaveTextContent('Hello world');
+```
+
+**Parameters:**
+- `expectedText`: The exact text content to match
+
+### toMatchTextContent(pattern: RegExp)
+
+Checks that a tool call result contains text content matching the given regular expression pattern.
+
+```ts
+const result = await app.callTool('get_status', {});
+await expect(result).toMatchTextContent(/Status: \w+/);
+```
+
+**Parameters:**
+- `pattern`: A regular expression to match against the text content
+
+**Example:**
+
+```ts
+import { mcpShell } from 'expect-mcp';
+
+test('validate tool result content', async () => {
+  const app = mcpShell('node file-server.js');
+  await app.initialize();
+
+  const result = await app.callTool('read_file', {
+    path: '/tmp/log.txt'
+  });
+
+  // Check that the tool call succeeded
+  await expect(result).toBeSuccessful();
+
+  // Check exact text match
+  await expect(result).toHaveTextContent('Log entry 1\nLog entry 2');
+
+  // Check pattern match
+  await expect(result).toMatchTextContent(/Log entry \d+/);
+
+  await app.close();
+});
+```
+
+## MCP Server Matchers
+
+These matchers work with `MCPStdinSubprocess` instances.
+
 ## toHaveTool(toolName: string)
 
 Checks that an MCP server provides a tool with the specified name. This matcher works with `MCPStdinSubprocess` instances.

--- a/docs-site/docs/matchers.md
+++ b/docs-site/docs/matchers.md
@@ -70,6 +70,55 @@ test('validate tool result content', async () => {
 });
 ```
 
+## Resource Result Matchers
+
+These matchers work with `ReadResourceResult` instances returned by `app.readResource()`.
+
+### toHaveResourceContent(uri: string)
+
+Checks that a resource result contains content for a specific URI.
+
+```ts
+const result = await app.readResource('file:///app/config.json');
+await expect(result).toHaveResourceContent('file:///app/config.json');
+```
+
+**Parameters:**
+- `uri`: The URI to check for in the resource contents
+
+### toHaveTextResource(expectedText: string)
+
+Checks that a resource result contains text content matching the expected string exactly.
+
+```ts
+const result = await app.readResource('file:///app/test.txt');
+await expect(result).toHaveTextResource('Hello world');
+```
+
+**Parameters:**
+- `expectedText`: The exact text content to match
+
+**Example:**
+
+```ts
+import { mcpShell } from 'expect-mcp';
+
+test('validate resource content', async () => {
+  const app = mcpShell('node file-server.js');
+  await app.initialize();
+
+  const result = await app.readResource('file:///app/config.json');
+
+  // Check that the resource has content for the URI
+  await expect(result).toHaveResourceContent('file:///app/config.json');
+
+  // Check exact text match
+  await expect(result).toHaveTextResource('{"key": "value"}');
+
+  await app.close();
+});
+```
+
 ## MCP Server Matchers
 
 These matchers work with `MCPStdinSubprocess` instances.

--- a/docs-site/docs/readResource.md
+++ b/docs-site/docs/readResource.md
@@ -10,7 +10,7 @@ Will throw an error if:
 ## Syntax
 
 ```ts
-app.readResource(uri: string): Promise<MCPReadResourceResult>
+app.readResource(uri: string): Promise<ReadResourceResult>
 ```
 
 ## Parameters
@@ -19,14 +19,13 @@ app.readResource(uri: string): Promise<MCPReadResourceResult>
 
 ## Returns
 
-A Promise that resolves to an object containing:
-- `contents`: An array of resource contents (text or blob)
+A Promise that resolves to a [`ReadResourceResult`](ReadResourceResult) instance containing the resource contents.
 
-Each content item has:
-- `uri`: The URI of the resource
-- `mimeType`: Optional MIME type of the content
-- `text`: The text content (for text resources)
-- `blob`: The base64-encoded blob content (for binary resources)
+The result provides helper methods for accessing content:
+- `.getTextContent()`: Get text from the first text resource
+- `.getBlobContent()`: Get blob from the first blob resource
+- `.findByUri(uri)`: Find a resource by its URI
+- `.contents`: Access the raw contents array
 
 ## Example
 
@@ -41,9 +40,16 @@ test('read a resource from the server', async () => {
   // Read a text resource
   const result = await app.readResource('file:///example.txt');
 
+  // result is a ReadResourceResult instance
   expect(result.contents).toBeDefined();
-  expect(result.contents[0].text).toBeDefined();
-  expect(result.contents[0].mimeType).toBe('text/plain');
+
+  // Use helper methods
+  const text = result.getTextContent();
+  expect(text).toBeDefined();
+
+  // Or use matchers
+  await expect(result).toHaveResourceContent('file:///example.txt');
+  await expect(result).toHaveTextResource('expected content');
 
   await app.close();
 });
@@ -75,6 +81,8 @@ const result = await app.readResource('file:///large-file.txt');
 
 ## See Also
 
+- [ReadResourceResult](ReadResourceResult) - The class returned by readResource
 - [mcpShell](mcpShell) - Create an MCP subprocess
 - [toHaveResource](toHaveResource) - Assert that a resource exists
 - [toHaveResources](toHaveResources) - Assert that multiple resources exist
+- [Matchers](matchers) - Custom matchers for validating resource results

--- a/src/MCPStdinSubprocess.ts
+++ b/src/MCPStdinSubprocess.ts
@@ -1,13 +1,14 @@
 import { ProtocolError, ResourceCallError, ToolCallError } from './errors.js';
 import { JsonRpcSubprocess, JsonRpcSubprocessOptions } from './JsonRPCSubprocess.js';
+import { ReadResourceResult } from './ReadResourceResult.js';
 import { LATEST_PROTOCOL_VERSION } from './schemas/index.js';
 import { InitializeResultSchema } from './schemas/initialization.js';
+import { ReadResourceResultSchema } from './schemas/resources.js';
 import { CallToolResultSchema } from './schemas/tools.js';
 import { ToolCallResult } from './ToolCallResult.js';
 import {
   MCPInitializeParams,
   MCPInitializeResult,
-  MCPReadResourceResult,
   MCPResource,
   MCPResourcesListResult,
   MCPTool,
@@ -237,7 +238,7 @@ export class MCPStdinSubprocess extends JsonRpcSubprocess {
     return new ToolCallResult(validation.data);
   }
 
-  async readResource(uri: string): Promise<MCPReadResourceResult> {
+  async readResource(uri: string): Promise<ReadResourceResult> {
     await this._implicitInitialize();
 
     if (!(await this.supportsResources())) {
@@ -253,11 +254,19 @@ export class MCPStdinSubprocess extends JsonRpcSubprocess {
       throw new ResourceCallError(`Resource with URI ${uri} not declared in resources/list`);
     }
 
-    const response: MCPReadResourceResult = await this.sendRequest('resources/read', {
+    const response = await this.sendRequest('resources/read', {
       uri,
     });
 
-    return response;
+    // Validate the response against the schema
+    const validation = ReadResourceResultSchema.safeParse(response);
+    if (!validation.success) {
+      throw new ProtocolError(
+        `Response to resources/read failed schema validation: ${validation.error.message}`
+      );
+    }
+
+    return new ReadResourceResult(validation.data);
   }
 
   getInitializeResult(): MCPInitializeResult | undefined {

--- a/src/ReadResourceResult.ts
+++ b/src/ReadResourceResult.ts
@@ -1,0 +1,122 @@
+import type {
+  BlobResourceContents,
+  ReadResourceResult as ReadResourceResultType,
+  TextResourceContents,
+} from './schemas/resources.js';
+
+/**
+ * Wraps the result of a resource read with helper methods for accessing content.
+ */
+export class ReadResourceResult {
+  private _result: ReadResourceResultType;
+
+  constructor(result: ReadResourceResultType) {
+    this._result = result;
+  }
+
+  /**
+   * Get the raw result object.
+   */
+  get raw(): ReadResourceResultType {
+    return this._result;
+  }
+
+  /**
+   * Get the contents array.
+   */
+  get contents(): (TextResourceContents | BlobResourceContents)[] {
+    return this._result.contents;
+  }
+
+  /**
+   * Get the text content from the first text resource in the contents array.
+   *
+   * @returns The text content, or undefined if no text resources exist.
+   *
+   * @example
+   * ```ts
+   * const result = await app.readResource('file:///app/test.txt');
+   * const text = result.getTextContent();
+   * ```
+   */
+  getTextContent(): string | undefined {
+    const textResource = this._result.contents.find(
+      (content): content is TextResourceContents => 'text' in content
+    );
+    return textResource?.text;
+  }
+
+  /**
+   * Get the blob content from the first blob resource in the contents array.
+   *
+   * @returns The blob content (base64-encoded), or undefined if no blob resources exist.
+   *
+   * @example
+   * ```ts
+   * const result = await app.readResource('file:///app/image.png');
+   * const blob = result.getBlobContent();
+   * ```
+   */
+  getBlobContent(): string | undefined {
+    const blobResource = this._result.contents.find(
+      (content): content is BlobResourceContents => 'blob' in content
+    );
+    return blobResource?.blob;
+  }
+
+  /**
+   * Find a resource by its URI.
+   *
+   * @param uri The URI of the resource to find.
+   * @returns The resource with the matching URI, or undefined.
+   *
+   * @example
+   * ```ts
+   * const result = await app.readResource('file:///app/test.txt');
+   * const resource = result.findByUri('file:///app/test.txt');
+   * ```
+   */
+  findByUri(uri: string): TextResourceContents | BlobResourceContents | undefined {
+    return this._result.contents.find(content => content.uri === uri);
+  }
+
+  /**
+   * Get all text resources from the contents array.
+   *
+   * @returns An array of text resources.
+   */
+  getAllTextResources(): TextResourceContents[] {
+    return this._result.contents.filter(
+      (content): content is TextResourceContents => 'text' in content
+    );
+  }
+
+  /**
+   * Get all blob resources from the contents array.
+   *
+   * @returns An array of blob resources.
+   */
+  getAllBlobResources(): BlobResourceContents[] {
+    return this._result.contents.filter(
+      (content): content is BlobResourceContents => 'blob' in content
+    );
+  }
+
+  /**
+   * Check if the result contains any text resources.
+   *
+   * @returns True if at least one text resource exists.
+   */
+  hasTextContent(): boolean {
+    return this._result.contents.some(content => 'text' in content);
+  }
+
+  /**
+   * Check if the result contains any blob resources.
+   *
+   * @returns True if at least one blob resource exists.
+   */
+  hasBlobContent(): boolean {
+    return this._result.contents.some(content => 'blob' in content);
+  }
+}

--- a/src/ToolCallResult.ts
+++ b/src/ToolCallResult.ts
@@ -1,0 +1,110 @@
+import { ToolCallError } from './errors.js';
+import type { CallToolResult, ContentBlock, TextContent } from './schemas/tools.js';
+
+/**
+ * Wraps the result of a tool call with helper methods for accessing content.
+ */
+export class ToolCallResult {
+  private _result: CallToolResult;
+
+  constructor(result: CallToolResult) {
+    this._result = result;
+  }
+
+  /**
+   * Get the raw result object.
+   */
+  get raw(): CallToolResult {
+    return this._result;
+  }
+
+  /**
+   * Get the content array.
+   */
+  get content(): ContentBlock[] {
+    return this._result.content;
+  }
+
+  /**
+   * Get the structured content if present.
+   */
+  get structuredContent(): Record<string, unknown> | undefined {
+    return this._result.structuredContent;
+  }
+
+  /**
+   * Check if the result is an error.
+   */
+  get isError(): boolean {
+    return this._result.isError === true;
+  }
+
+  /**
+   * Get the text content from the first text content block.
+   *
+   * @returns The text content, or undefined if no text content blocks exist.
+   *
+   * @example
+   * ```ts
+   * const result = await app.callTool('read_file', {path: '/app/test.txt'});
+   * const text = result.getTextContent();
+   * ```
+   */
+  getTextContent(): string | undefined {
+    const textBlock = this._result.content.find(
+      (block): block is TextContent => block.type === 'text'
+    );
+    return textBlock?.text;
+  }
+
+  /**
+   * Assert that the result is not an error.
+   *
+   * @throws {ToolCallError} If the result has isError set to true.
+   * @returns This ToolCallResult instance for chaining.
+   *
+   * @example
+   * ```ts
+   * const result = await app.callTool('write_file', {...});
+   * result.expectSuccess(); // Throws if isError is true
+   * ```
+   */
+  expectSuccess(): this {
+    if (this._result.isError) {
+      const textContent = this.getTextContent();
+      const errorMessage = textContent
+        ? `Tool call failed with error: ${textContent}`
+        : 'Tool call failed with error (no text content available)';
+      throw new ToolCallError(errorMessage);
+    }
+    return this;
+  }
+
+  /**
+   * Get all content blocks of a specific type.
+   *
+   * @param type The type of content blocks to retrieve.
+   * @returns An array of content blocks matching the specified type.
+   */
+  getContentByType<T extends ContentBlock['type']>(
+    type: T
+  ): Extract<ContentBlock, { type: T }>[] {
+    return this._result.content.filter(
+      (block): block is Extract<ContentBlock, { type: T }> => block.type === type
+    );
+  }
+
+  /**
+   * Find a content block by type.
+   *
+   * @param type The type of content block to find.
+   * @returns The first content block of the specified type, or undefined.
+   */
+  findContentByType<T extends ContentBlock['type']>(
+    type: T
+  ): Extract<ContentBlock, { type: T }> | undefined {
+    return this._result.content.find(
+      (block): block is Extract<ContentBlock, { type: T }> => block.type === type
+    );
+  }
+}

--- a/src/__tests__/ReadResourceResult.test.ts
+++ b/src/__tests__/ReadResourceResult.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from 'vitest';
+import { ReadResourceResult } from '../ReadResourceResult.js';
+import type { ReadResourceResult as ReadResourceResultType } from '../schemas/resources.js';
+
+describe('ReadResourceResult', () => {
+  describe('constructor and getters', () => {
+    it('should create an instance from a valid result', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult).toBeInstanceOf(ReadResourceResult);
+      expect(resourceResult.raw).toBe(result);
+      expect(resourceResult.contents).toBe(result.contents);
+    });
+
+    it('should handle resources with metadata', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            name: 'test.txt',
+            title: 'Test File',
+            mimeType: 'text/plain',
+            text: 'Hello world',
+            annotations: {
+              audience: ['user'],
+              priority: 0.8,
+            },
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.contents[0].name).toBe('test.txt');
+      expect(resourceResult.contents[0].title).toBe('Test File');
+      expect(resourceResult.contents[0].annotations?.priority).toBe(0.8);
+    });
+  });
+
+  describe('getTextContent', () => {
+    it('should return text from the first text resource', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getTextContent()).toBe('Hello world');
+    });
+
+    it('should return text from the first text resource when multiple exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test1.txt',
+            text: 'First text',
+          },
+          {
+            uri: 'file:///app/test2.txt',
+            text: 'Second text',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getTextContent()).toBe('First text');
+    });
+
+    it('should return undefined when no text resources exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image.png',
+            blob: 'base64data',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getTextContent()).toBeUndefined();
+    });
+
+    it('should return undefined when contents array is empty', () => {
+      const result: ReadResourceResultType = {
+        contents: [],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getTextContent()).toBeUndefined();
+    });
+  });
+
+  describe('getBlobContent', () => {
+    it('should return blob from the first blob resource', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image.png',
+            blob: 'base64data',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getBlobContent()).toBe('base64data');
+    });
+
+    it('should return blob from the first blob resource when multiple exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image1.png',
+            blob: 'base64data1',
+          },
+          {
+            uri: 'file:///app/image2.png',
+            blob: 'base64data2',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getBlobContent()).toBe('base64data1');
+    });
+
+    it('should return undefined when no blob resources exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.getBlobContent()).toBeUndefined();
+    });
+  });
+
+  describe('findByUri', () => {
+    it('should find a resource by its URI', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const found = resourceResult.findByUri('file:///app/test.txt');
+      expect(found).toBeDefined();
+      expect(found?.uri).toBe('file:///app/test.txt');
+    });
+
+    it('should return undefined when URI is not found', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const found = resourceResult.findByUri('file:///app/other.txt');
+      expect(found).toBeUndefined();
+    });
+
+    it('should find the correct resource when multiple exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test1.txt',
+            text: 'First',
+          },
+          {
+            uri: 'file:///app/test2.txt',
+            text: 'Second',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const found = resourceResult.findByUri('file:///app/test2.txt');
+      expect(found).toBeDefined();
+      if ('text' in found!) {
+        expect(found.text).toBe('Second');
+      }
+    });
+  });
+
+  describe('getAllTextResources', () => {
+    it('should return all text resources', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test1.txt',
+            text: 'First text',
+          },
+          {
+            uri: 'file:///app/image.png',
+            blob: 'base64data',
+          },
+          {
+            uri: 'file:///app/test2.txt',
+            text: 'Second text',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const textResources = resourceResult.getAllTextResources();
+      expect(textResources).toHaveLength(2);
+      expect(textResources[0].text).toBe('First text');
+      expect(textResources[1].text).toBe('Second text');
+    });
+
+    it('should return empty array when no text resources exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image.png',
+            blob: 'base64data',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const textResources = resourceResult.getAllTextResources();
+      expect(textResources).toHaveLength(0);
+    });
+  });
+
+  describe('getAllBlobResources', () => {
+    it('should return all blob resources', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image1.png',
+            blob: 'base64data1',
+          },
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Some text',
+          },
+          {
+            uri: 'file:///app/image2.png',
+            blob: 'base64data2',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const blobResources = resourceResult.getAllBlobResources();
+      expect(blobResources).toHaveLength(2);
+      expect(blobResources[0].blob).toBe('base64data1');
+      expect(blobResources[1].blob).toBe('base64data2');
+    });
+
+    it('should return empty array when no blob resources exist', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      const blobResources = resourceResult.getAllBlobResources();
+      expect(blobResources).toHaveLength(0);
+    });
+  });
+
+  describe('hasTextContent', () => {
+    it('should return true when text content exists', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.hasTextContent()).toBe(true);
+    });
+
+    it('should return false when no text content exists', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image.png',
+            blob: 'base64data',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.hasTextContent()).toBe(false);
+    });
+
+    it('should return false when contents array is empty', () => {
+      const result: ReadResourceResultType = {
+        contents: [],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.hasTextContent()).toBe(false);
+    });
+  });
+
+  describe('hasBlobContent', () => {
+    it('should return true when blob content exists', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/image.png',
+            blob: 'base64data',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.hasBlobContent()).toBe(true);
+    });
+
+    it('should return false when no blob content exists', () => {
+      const result: ReadResourceResultType = {
+        contents: [
+          {
+            uri: 'file:///app/test.txt',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.hasBlobContent()).toBe(false);
+    });
+
+    it('should return false when contents array is empty', () => {
+      const result: ReadResourceResultType = {
+        contents: [],
+      };
+
+      const resourceResult = new ReadResourceResult(result);
+      expect(resourceResult.hasBlobContent()).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/ToolCallResult.test.ts
+++ b/src/__tests__/ToolCallResult.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'vitest';
+import { ToolCallResult } from '../ToolCallResult.js';
+import { ToolCallError } from '../errors.js';
+import type { CallToolResult } from '../schemas/tools.js';
+
+describe('ToolCallResult', () => {
+  describe('constructor and getters', () => {
+    it('should create an instance from a valid result', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Hello world',
+          },
+        ],
+        isError: false,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult).toBeInstanceOf(ToolCallResult);
+      expect(toolResult.raw).toBe(result);
+      expect(toolResult.content).toBe(result.content);
+      expect(toolResult.isError).toBe(false);
+    });
+
+    it('should expose structured content when present', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: '{"key": "value"}',
+          },
+        ],
+        structuredContent: { key: 'value' },
+        isError: false,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.structuredContent).toEqual({ key: 'value' });
+    });
+
+    it('should have undefined structuredContent when not present', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.structuredContent).toBeUndefined();
+    });
+  });
+
+  describe('getTextContent', () => {
+    it('should return text from the first text content block', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Hello world',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.getTextContent()).toBe('Hello world');
+    });
+
+    it('should return text from the first text block when multiple blocks exist', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'image',
+            data: 'base64data',
+            mimeType: 'image/png',
+          },
+          {
+            type: 'text',
+            text: 'First text',
+          },
+          {
+            type: 'text',
+            text: 'Second text',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.getTextContent()).toBe('First text');
+    });
+
+    it('should return undefined when no text content exists', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'image',
+            data: 'base64data',
+            mimeType: 'image/png',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.getTextContent()).toBeUndefined();
+    });
+
+    it('should return undefined when content array is empty', () => {
+      const result: CallToolResult = {
+        content: [],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.getTextContent()).toBeUndefined();
+    });
+  });
+
+  describe('expectSuccess', () => {
+    it('should return the instance when result is successful', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Success',
+          },
+        ],
+        isError: false,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.expectSuccess()).toBe(toolResult);
+    });
+
+    it('should return the instance when isError is undefined', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Success',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.expectSuccess()).toBe(toolResult);
+    });
+
+    it('should throw ToolCallError when result has isError set to true', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Something went wrong',
+          },
+        ],
+        isError: true,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(() => toolResult.expectSuccess()).toThrow(ToolCallError);
+      expect(() => toolResult.expectSuccess()).toThrow('Something went wrong');
+    });
+
+    it('should throw with a generic message when isError is true but no text content', () => {
+      const result: CallToolResult = {
+        content: [],
+        isError: true,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(() => toolResult.expectSuccess()).toThrow(ToolCallError);
+      expect(() => toolResult.expectSuccess()).toThrow('no text content available');
+    });
+  });
+
+  describe('getContentByType', () => {
+    it('should return all text content blocks', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'First text',
+          },
+          {
+            type: 'image',
+            data: 'base64data',
+            mimeType: 'image/png',
+          },
+          {
+            type: 'text',
+            text: 'Second text',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      const textBlocks = toolResult.getContentByType('text');
+      expect(textBlocks).toHaveLength(2);
+      expect(textBlocks[0].text).toBe('First text');
+      expect(textBlocks[1].text).toBe('Second text');
+    });
+
+    it('should return empty array when no blocks match the type', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Only text',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      const imageBlocks = toolResult.getContentByType('image');
+      expect(imageBlocks).toHaveLength(0);
+    });
+
+    it('should return all image content blocks', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'image',
+            data: 'data1',
+            mimeType: 'image/png',
+          },
+          {
+            type: 'text',
+            text: 'Some text',
+          },
+          {
+            type: 'image',
+            data: 'data2',
+            mimeType: 'image/jpeg',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      const imageBlocks = toolResult.getContentByType('image');
+      expect(imageBlocks).toHaveLength(2);
+      expect(imageBlocks[0].data).toBe('data1');
+      expect(imageBlocks[1].data).toBe('data2');
+    });
+  });
+
+  describe('findContentByType', () => {
+    it('should return the first content block of the specified type', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'image',
+            data: 'base64data',
+            mimeType: 'image/png',
+          },
+          {
+            type: 'text',
+            text: 'First text',
+          },
+          {
+            type: 'text',
+            text: 'Second text',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      const textBlock = toolResult.findContentByType('text');
+      expect(textBlock).toBeDefined();
+      expect(textBlock?.text).toBe('First text');
+    });
+
+    it('should return undefined when no block matches the type', () => {
+      const result: CallToolResult = {
+        content: [
+          {
+            type: 'text',
+            text: 'Only text',
+          },
+        ],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      const imageBlock = toolResult.findContentByType('image');
+      expect(imageBlock).toBeUndefined();
+    });
+  });
+
+  describe('isError', () => {
+    it('should return true when isError is true', () => {
+      const result: CallToolResult = {
+        content: [],
+        isError: true,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.isError).toBe(true);
+    });
+
+    it('should return false when isError is false', () => {
+      const result: CallToolResult = {
+        content: [],
+        isError: false,
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.isError).toBe(false);
+    });
+
+    it('should return false when isError is undefined', () => {
+      const result: CallToolResult = {
+        content: [],
+      };
+
+      const toolResult = new ToolCallResult(result);
+      expect(toolResult.isError).toBe(false);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { MCPMatchers } from './types.js';
 
 export { mcpShell } from './mcpShellCommand.js';
 export { MCPStdinSubprocess } from './MCPStdinSubprocess.js';
+export { ToolCallResult } from './ToolCallResult.js';
 
 declare module 'vitest' {
   interface Assertion<T = any> extends MCPMatchers {}
@@ -31,3 +32,17 @@ export type {
   MCPTool,
   MCPToolsListResult,
 } from './types/MCP.js';
+
+export type {
+  AudioContent,
+  CallToolRequest,
+  CallToolResult,
+  ContentBlock,
+  EmbeddedResourceContent,
+  ImageContent,
+  ResourceLinkContent,
+  TextContent,
+  Tool,
+  ToolAnnotations,
+  ToolCallResult as ToolCallResultType,
+} from './schemas/tools.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { MCPMatchers } from './types.js';
 export { mcpShell } from './mcpShellCommand.js';
 export { MCPStdinSubprocess } from './MCPStdinSubprocess.js';
 export { ToolCallResult } from './ToolCallResult.js';
+export { ReadResourceResult } from './ReadResourceResult.js';
 
 declare module 'vitest' {
   interface Assertion<T = any> extends MCPMatchers {}
@@ -46,3 +47,12 @@ export type {
   ToolAnnotations,
   ToolCallResult as ToolCallResultType,
 } from './schemas/tools.js';
+
+export type {
+  Annotations,
+  BlobResourceContents,
+  ReadResourceResult as ReadResourceResultType,
+  Resource,
+  ResourceContents,
+  TextResourceContents,
+} from './schemas/resources.js';

--- a/src/matchers/__tests__/toBeSuccessful.test.ts
+++ b/src/matchers/__tests__/toBeSuccessful.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import '../../vitest-setup.js';
+import { ToolCallResult } from '../../ToolCallResult.js';
+import { resolveUtils } from '../../utils.js';
+import { toBeSuccessful } from '../toBeSuccessful.js';
+import type { CallToolResult } from '../../schemas/tools.js';
+
+// Mock the resolveUtils function
+vi.mock('../../utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils.js')>();
+  return {
+    ...actual,
+    resolveUtils: vi.fn(() => ({
+      printReceived: vi.fn(value => `received: ${JSON.stringify(value)}`),
+      printExpected: vi.fn(value => `expected: ${JSON.stringify(value)}`),
+    })),
+  };
+});
+
+describe('toBeSuccessful', () => {
+  const mockContext = {};
+
+  it('should pass when tool result is successful', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Success',
+        },
+      ],
+      isError: false,
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toBeSuccessful.call(mockContext, toolResult);
+
+    expect(matcherResult.pass).toBe(true);
+    expect(matcherResult.message()).toContain('Expected tool call to have failed');
+  });
+
+  it('should pass when isError is undefined', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Success',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toBeSuccessful.call(mockContext, toolResult);
+
+    expect(matcherResult.pass).toBe(true);
+  });
+
+  it('should fail when tool result has error', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Error occurred',
+        },
+      ],
+      isError: true,
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toBeSuccessful.call(mockContext, toolResult);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected tool call to succeed');
+    expect(matcherResult.message()).toContain('Error occurred');
+  });
+
+  it('should fail with generic message when isError is true but no text content', async () => {
+    const result: CallToolResult = {
+      content: [],
+      isError: true,
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toBeSuccessful.call(mockContext, toolResult);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected tool call to succeed');
+    expect(matcherResult.message()).not.toContain(':');
+  });
+
+  it('should fail when received is not a ToolCallResult instance', async () => {
+    const notToolResult = { someProperty: 'value' };
+
+    const matcherResult = await toBeSuccessful.call(mockContext, notToolResult);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected');
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should fail when received is null', async () => {
+    const matcherResult = await toBeSuccessful.call(mockContext, null);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should fail when received is undefined', async () => {
+    const matcherResult = await toBeSuccessful.call(mockContext, undefined);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should call resolveUtils with the correct context', async () => {
+    const result: CallToolResult = {
+      content: [],
+      isError: false,
+    };
+    const toolResult = new ToolCallResult(result);
+
+    await toBeSuccessful.call(mockContext, toolResult);
+
+    expect(resolveUtils).toHaveBeenCalledWith(mockContext);
+  });
+});

--- a/src/matchers/__tests__/toHaveResourceContent.test.ts
+++ b/src/matchers/__tests__/toHaveResourceContent.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import '../../vitest-setup.js';
+import { ReadResourceResult } from '../../ReadResourceResult.js';
+import { resolveUtils } from '../../utils.js';
+import { toHaveResourceContent } from '../toHaveResourceContent.js';
+import type { ReadResourceResult as ReadResourceResultType } from '../../schemas/resources.js';
+
+// Mock the resolveUtils function
+vi.mock('../../utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils.js')>();
+  return {
+    ...actual,
+    resolveUtils: vi.fn(() => ({
+      printReceived: vi.fn(value => `received: ${JSON.stringify(value)}`),
+      printExpected: vi.fn(value => `expected: ${JSON.stringify(value)}`),
+    })),
+  };
+});
+
+describe('toHaveResourceContent', () => {
+  const mockContext = {};
+
+  it('should pass when resource result has content for the URI', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test.txt',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveResourceContent.call(
+      mockContext,
+      resourceResult,
+      'file:///app/test.txt'
+    );
+
+    expect(matcherResult.pass).toBe(true);
+    expect(matcherResult.message()).toContain('Expected resource result not to have content for URI');
+  });
+
+  it('should fail when resource result does not have content for the URI', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test.txt',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveResourceContent.call(
+      mockContext,
+      resourceResult,
+      'file:///app/other.txt'
+    );
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected resource result to have content for URI');
+    expect(matcherResult.message()).toContain('other.txt');
+  });
+
+  it('should find the correct resource when multiple exist', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test1.txt',
+          text: 'First',
+        },
+        {
+          uri: 'file:///app/test2.txt',
+          text: 'Second',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveResourceContent.call(
+      mockContext,
+      resourceResult,
+      'file:///app/test2.txt'
+    );
+
+    expect(matcherResult.pass).toBe(true);
+  });
+
+  it('should fail when received is not a ReadResourceResult instance', async () => {
+    const notResourceResult = { someProperty: 'value' };
+
+    const matcherResult = await toHaveResourceContent.call(
+      mockContext,
+      notResourceResult,
+      'file:///app/test.txt'
+    );
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ReadResourceResult instance');
+  });
+
+  it('should fail when received is null', async () => {
+    const matcherResult = await toHaveResourceContent.call(
+      mockContext,
+      null,
+      'file:///app/test.txt'
+    );
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ReadResourceResult instance');
+  });
+
+  it('should fail when received is undefined', async () => {
+    const matcherResult = await toHaveResourceContent.call(
+      mockContext,
+      undefined,
+      'file:///app/test.txt'
+    );
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ReadResourceResult instance');
+  });
+
+  it('should call resolveUtils with the correct context', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test.txt',
+          text: 'Hello',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    await toHaveResourceContent.call(mockContext, resourceResult, 'file:///app/test.txt');
+
+    expect(resolveUtils).toHaveBeenCalledWith(mockContext);
+  });
+});

--- a/src/matchers/__tests__/toHaveTextContent.test.ts
+++ b/src/matchers/__tests__/toHaveTextContent.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import '../../vitest-setup.js';
+import { ToolCallResult } from '../../ToolCallResult.js';
+import { resolveUtils } from '../../utils.js';
+import { toHaveTextContent } from '../toHaveTextContent.js';
+import type { CallToolResult } from '../../schemas/tools.js';
+
+// Mock the resolveUtils function
+vi.mock('../../utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils.js')>();
+  return {
+    ...actual,
+    resolveUtils: vi.fn(() => ({
+      printReceived: vi.fn(value => `received: ${JSON.stringify(value)}`),
+      printExpected: vi.fn(value => `expected: ${JSON.stringify(value)}`),
+    })),
+  };
+});
+
+describe('toHaveTextContent', () => {
+  const mockContext = {};
+
+  it('should pass when tool result has matching text content', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toHaveTextContent.call(mockContext, toolResult, 'Hello world');
+
+    expect(matcherResult.pass).toBe(true);
+    expect(matcherResult.message()).toContain('Expected tool result not to have text content');
+  });
+
+  it('should fail when text content does not match', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toHaveTextContent.call(mockContext, toolResult, 'Goodbye world');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected tool result to have text content');
+    expect(matcherResult.message()).toContain('Goodbye world');
+    expect(matcherResult.message()).toContain('Hello world');
+  });
+
+  it('should fail when tool result has no text content', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'image',
+          data: 'base64data',
+          mimeType: 'image/png',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toHaveTextContent.call(mockContext, toolResult, 'Any text');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected tool result to have text content');
+    expect(matcherResult.message()).toContain('but it has none');
+  });
+
+  it('should fail when content array is empty', async () => {
+    const result: CallToolResult = {
+      content: [],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toHaveTextContent.call(mockContext, toolResult, 'Any text');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('but it has none');
+  });
+
+  it('should fail when received is not a ToolCallResult instance', async () => {
+    const notToolResult = { someProperty: 'value' };
+
+    const matcherResult = await toHaveTextContent.call(mockContext, notToolResult, 'test');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should fail when received is null', async () => {
+    const matcherResult = await toHaveTextContent.call(mockContext, null, 'test');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should fail when received is undefined', async () => {
+    const matcherResult = await toHaveTextContent.call(mockContext, undefined, 'test');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should call resolveUtils with the correct context', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Hello',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    await toHaveTextContent.call(mockContext, toolResult, 'Hello');
+
+    expect(resolveUtils).toHaveBeenCalledWith(mockContext);
+  });
+});

--- a/src/matchers/__tests__/toHaveTextResource.test.ts
+++ b/src/matchers/__tests__/toHaveTextResource.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+import '../../vitest-setup.js';
+import { ReadResourceResult } from '../../ReadResourceResult.js';
+import { resolveUtils } from '../../utils.js';
+import { toHaveTextResource } from '../toHaveTextResource.js';
+import type { ReadResourceResult as ReadResourceResultType } from '../../schemas/resources.js';
+
+// Mock the resolveUtils function
+vi.mock('../../utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils.js')>();
+  return {
+    ...actual,
+    resolveUtils: vi.fn(() => ({
+      printReceived: vi.fn(value => `received: ${JSON.stringify(value)}`),
+      printExpected: vi.fn(value => `expected: ${JSON.stringify(value)}`),
+    })),
+  };
+});
+
+describe('toHaveTextResource', () => {
+  const mockContext = {};
+
+  it('should pass when resource result has matching text content', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test.txt',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveTextResource.call(mockContext, resourceResult, 'Hello world');
+
+    expect(matcherResult.pass).toBe(true);
+    expect(matcherResult.message()).toContain('Expected resource result not to have text content');
+  });
+
+  it('should fail when text content does not match', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test.txt',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveTextResource.call(mockContext, resourceResult, 'Goodbye world');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected resource result to have text content');
+    expect(matcherResult.message()).toContain('Goodbye world');
+    expect(matcherResult.message()).toContain('Hello world');
+  });
+
+  it('should fail when resource result has no text content', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/image.png',
+          blob: 'base64data',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveTextResource.call(mockContext, resourceResult, 'Any text');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected resource result to have text content');
+    expect(matcherResult.message()).toContain('but it has none');
+  });
+
+  it('should fail when contents array is empty', async () => {
+    const result: ReadResourceResultType = {
+      contents: [],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    const matcherResult = await toHaveTextResource.call(mockContext, resourceResult, 'Any text');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('but it has none');
+  });
+
+  it('should fail when received is not a ReadResourceResult instance', async () => {
+    const notResourceResult = { someProperty: 'value' };
+
+    const matcherResult = await toHaveTextResource.call(mockContext, notResourceResult, 'test');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ReadResourceResult instance');
+  });
+
+  it('should fail when received is null', async () => {
+    const matcherResult = await toHaveTextResource.call(mockContext, null, 'test');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ReadResourceResult instance');
+  });
+
+  it('should fail when received is undefined', async () => {
+    const matcherResult = await toHaveTextResource.call(mockContext, undefined, 'test');
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ReadResourceResult instance');
+  });
+
+  it('should call resolveUtils with the correct context', async () => {
+    const result: ReadResourceResultType = {
+      contents: [
+        {
+          uri: 'file:///app/test.txt',
+          text: 'Hello',
+        },
+      ],
+    };
+    const resourceResult = new ReadResourceResult(result);
+
+    await toHaveTextResource.call(mockContext, resourceResult, 'Hello');
+
+    expect(resolveUtils).toHaveBeenCalledWith(mockContext);
+  });
+});

--- a/src/matchers/__tests__/toMatchTextContent.test.ts
+++ b/src/matchers/__tests__/toMatchTextContent.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import '../../vitest-setup.js';
+import { ToolCallResult } from '../../ToolCallResult.js';
+import { resolveUtils } from '../../utils.js';
+import { toMatchTextContent } from '../toMatchTextContent.js';
+import type { CallToolResult } from '../../schemas/tools.js';
+
+// Mock the resolveUtils function
+vi.mock('../../utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils.js')>();
+  return {
+    ...actual,
+    resolveUtils: vi.fn(() => ({
+      printReceived: vi.fn(value => `received: ${JSON.stringify(value)}`),
+      printExpected: vi.fn(value => `expected: ${JSON.stringify(value)}`),
+    })),
+  };
+});
+
+describe('toMatchTextContent', () => {
+  const mockContext = {};
+
+  it('should pass when text content matches the pattern', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toMatchTextContent.call(mockContext, toolResult, /Hello/);
+
+    expect(matcherResult.pass).toBe(true);
+    expect(matcherResult.message()).toContain('Expected tool result not to match pattern');
+  });
+
+  it('should pass when text content matches a complex pattern', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Error: Something went wrong on line 42',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toMatchTextContent.call(
+      mockContext,
+      toolResult,
+      /Error:.*line \d+/
+    );
+
+    expect(matcherResult.pass).toBe(true);
+  });
+
+  it('should fail when text content does not match the pattern', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Hello world',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toMatchTextContent.call(mockContext, toolResult, /Goodbye/);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected tool result to match pattern');
+    expect(matcherResult.message()).toContain('Hello world');
+  });
+
+  it('should fail when tool result has no text content', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'image',
+          data: 'base64data',
+          mimeType: 'image/png',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toMatchTextContent.call(mockContext, toolResult, /test/);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('Expected tool result to have text content');
+    expect(matcherResult.message()).toContain('but it has none');
+  });
+
+  it('should fail when content array is empty', async () => {
+    const result: CallToolResult = {
+      content: [],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    const matcherResult = await toMatchTextContent.call(mockContext, toolResult, /test/);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('but it has none');
+  });
+
+  it('should fail when received is not a ToolCallResult instance', async () => {
+    const notToolResult = { someProperty: 'value' };
+
+    const matcherResult = await toMatchTextContent.call(mockContext, notToolResult, /test/);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should fail when received is null', async () => {
+    const matcherResult = await toMatchTextContent.call(mockContext, null, /test/);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should fail when received is undefined', async () => {
+    const matcherResult = await toMatchTextContent.call(mockContext, undefined, /test/);
+
+    expect(matcherResult.pass).toBe(false);
+    expect(matcherResult.message()).toContain('to be a ToolCallResult instance');
+  });
+
+  it('should call resolveUtils with the correct context', async () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: 'Hello',
+        },
+      ],
+    };
+    const toolResult = new ToolCallResult(result);
+
+    await toMatchTextContent.call(mockContext, toolResult, /Hello/);
+
+    expect(resolveUtils).toHaveBeenCalledWith(mockContext);
+  });
+});

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,8 +1,10 @@
 import { MCPMatcherImplementations } from '../types.js';
 import { toBeSuccessful } from './toBeSuccessful.js';
 import { toHaveResource } from './toHaveResource.js';
+import { toHaveResourceContent } from './toHaveResourceContent.js';
 import { toHaveResources } from './toHaveResources.js';
 import { toHaveTextContent } from './toHaveTextContent.js';
+import { toHaveTextResource } from './toHaveTextResource.js';
 import { toHaveTool } from './toHaveTool.js';
 import { toHaveTools } from './toHaveTools.js';
 import { toMatchTextContent } from './toMatchTextContent.js';
@@ -15,4 +17,6 @@ export const mcpMatchers: MCPMatcherImplementations = {
   toBeSuccessful,
   toHaveTextContent,
   toMatchTextContent,
+  toHaveResourceContent,
+  toHaveTextResource,
 };

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,12 +1,18 @@
 import { MCPMatcherImplementations } from '../types.js';
+import { toBeSuccessful } from './toBeSuccessful.js';
 import { toHaveResource } from './toHaveResource.js';
 import { toHaveResources } from './toHaveResources.js';
+import { toHaveTextContent } from './toHaveTextContent.js';
 import { toHaveTool } from './toHaveTool.js';
 import { toHaveTools } from './toHaveTools.js';
+import { toMatchTextContent } from './toMatchTextContent.js';
 
 export const mcpMatchers: MCPMatcherImplementations = {
   toHaveTool,
   toHaveTools,
   toHaveResource,
   toHaveResources,
+  toBeSuccessful,
+  toHaveTextContent,
+  toMatchTextContent,
 };

--- a/src/matchers/toBeSuccessful.ts
+++ b/src/matchers/toBeSuccessful.ts
@@ -1,0 +1,28 @@
+import { ToolCallResult } from '../ToolCallResult.js';
+import { MCPMatcherResult } from '../types.js';
+import { resolveUtils } from '../utils.js';
+
+export async function toBeSuccessful(
+  this: any,
+  received: unknown
+): Promise<MCPMatcherResult> {
+  const utils = resolveUtils(this);
+
+  if (!(received instanceof ToolCallResult)) {
+    return {
+      pass: false,
+      message: () =>
+        `Expected ${utils.printReceived(received)} to be a ToolCallResult instance`,
+    };
+  }
+
+  const isSuccess = !received.isError;
+
+  return {
+    pass: isSuccess,
+    message: () =>
+      isSuccess
+        ? `Expected tool call to have failed, but it succeeded`
+        : `Expected tool call to succeed, but it failed${received.getTextContent() ? `: ${received.getTextContent()}` : ''}`,
+  };
+}

--- a/src/matchers/toHaveResourceContent.ts
+++ b/src/matchers/toHaveResourceContent.ts
@@ -1,0 +1,30 @@
+import { ReadResourceResult } from '../ReadResourceResult.js';
+import { MCPMatcherResult } from '../types.js';
+import { resolveUtils } from '../utils.js';
+
+export async function toHaveResourceContent(
+  this: any,
+  received: unknown,
+  uri: string
+): Promise<MCPMatcherResult> {
+  const utils = resolveUtils(this);
+
+  if (!(received instanceof ReadResourceResult)) {
+    return {
+      pass: false,
+      message: () =>
+        `Expected ${utils.printReceived(received)} to be a ReadResourceResult instance`,
+    };
+  }
+
+  const resource = received.findByUri(uri);
+  const hasResource = resource !== undefined;
+
+  return {
+    pass: hasResource,
+    message: () =>
+      hasResource
+        ? `Expected resource result not to have content for URI ${utils.printExpected(uri)}, but it does`
+        : `Expected resource result to have content for URI ${utils.printExpected(uri)}, but it doesn't`,
+  };
+}

--- a/src/matchers/toHaveTextContent.ts
+++ b/src/matchers/toHaveTextContent.ts
@@ -1,0 +1,38 @@
+import { ToolCallResult } from '../ToolCallResult.js';
+import { MCPMatcherResult } from '../types.js';
+import { resolveUtils } from '../utils.js';
+
+export async function toHaveTextContent(
+  this: any,
+  received: unknown,
+  expectedText: string
+): Promise<MCPMatcherResult> {
+  const utils = resolveUtils(this);
+
+  if (!(received instanceof ToolCallResult)) {
+    return {
+      pass: false,
+      message: () =>
+        `Expected ${utils.printReceived(received)} to be a ToolCallResult instance`,
+    };
+  }
+
+  const textContent = received.getTextContent();
+
+  if (textContent === undefined) {
+    return {
+      pass: false,
+      message: () => `Expected tool result to have text content, but it has none`,
+    };
+  }
+
+  const matches = textContent === expectedText;
+
+  return {
+    pass: matches,
+    message: () =>
+      matches
+        ? `Expected tool result not to have text content ${utils.printExpected(expectedText)}, but it does`
+        : `Expected tool result to have text content ${utils.printExpected(expectedText)}, but got ${utils.printReceived(textContent)}`,
+  };
+}

--- a/src/matchers/toHaveTextResource.ts
+++ b/src/matchers/toHaveTextResource.ts
@@ -1,0 +1,38 @@
+import { ReadResourceResult } from '../ReadResourceResult.js';
+import { MCPMatcherResult } from '../types.js';
+import { resolveUtils } from '../utils.js';
+
+export async function toHaveTextResource(
+  this: any,
+  received: unknown,
+  expectedText: string
+): Promise<MCPMatcherResult> {
+  const utils = resolveUtils(this);
+
+  if (!(received instanceof ReadResourceResult)) {
+    return {
+      pass: false,
+      message: () =>
+        `Expected ${utils.printReceived(received)} to be a ReadResourceResult instance`,
+    };
+  }
+
+  const textContent = received.getTextContent();
+
+  if (textContent === undefined) {
+    return {
+      pass: false,
+      message: () => `Expected resource result to have text content, but it has none`,
+    };
+  }
+
+  const matches = textContent === expectedText;
+
+  return {
+    pass: matches,
+    message: () =>
+      matches
+        ? `Expected resource result not to have text content ${utils.printExpected(expectedText)}, but it does`
+        : `Expected resource result to have text content ${utils.printExpected(expectedText)}, but got ${utils.printReceived(textContent)}`,
+  };
+}

--- a/src/matchers/toMatchTextContent.ts
+++ b/src/matchers/toMatchTextContent.ts
@@ -1,0 +1,38 @@
+import { ToolCallResult } from '../ToolCallResult.js';
+import { MCPMatcherResult } from '../types.js';
+import { resolveUtils } from '../utils.js';
+
+export async function toMatchTextContent(
+  this: any,
+  received: unknown,
+  pattern: RegExp
+): Promise<MCPMatcherResult> {
+  const utils = resolveUtils(this);
+
+  if (!(received instanceof ToolCallResult)) {
+    return {
+      pass: false,
+      message: () =>
+        `Expected ${utils.printReceived(received)} to be a ToolCallResult instance`,
+    };
+  }
+
+  const textContent = received.getTextContent();
+
+  if (textContent === undefined) {
+    return {
+      pass: false,
+      message: () => `Expected tool result to have text content, but it has none`,
+    };
+  }
+
+  const matches = pattern.test(textContent);
+
+  return {
+    pass: matches,
+    message: () =>
+      matches
+        ? `Expected tool result not to match pattern ${utils.printExpected(pattern)}, but it does`
+        : `Expected tool result to match pattern ${utils.printExpected(pattern)}, but got ${utils.printReceived(textContent)}`,
+  };
+}

--- a/src/schemas/resources.ts
+++ b/src/schemas/resources.ts
@@ -27,7 +27,10 @@ export const ResourceTemplateSchema = BaseMetadataSchema.extend({
 
 export const ResourceContentsSchema = z.object({
   uri: z.string().url(),
+  name: z.string().optional(),
+  title: z.string().optional(),
   mimeType: z.string().optional(),
+  annotations: AnnotationsSchema.optional(),
   _meta: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -124,9 +127,12 @@ export const ResourceListChangedNotificationSchema = z.object({
   params: z.object({}).optional(),
 });
 
+export const ResourceReadResultSchema = ReadResourceResultSchema;
+
 export type Annotations = z.infer<typeof AnnotationsSchema>;
 export type Resource = z.infer<typeof ResourceSchema>;
 export type ResourceTemplate = z.infer<typeof ResourceTemplateSchema>;
+export type ResourceContents = z.infer<typeof ResourceContentsSchema>;
 export type TextResourceContents = z.infer<typeof TextResourceContentsSchema>;
 export type BlobResourceContents = z.infer<typeof BlobResourceContentsSchema>;
 export type EmbeddedResource = z.infer<typeof EmbeddedResourceSchema>;
@@ -135,3 +141,4 @@ export type ListResourcesRequest = z.infer<typeof ListResourcesRequestSchema>;
 export type ListResourcesResult = z.infer<typeof ListResourcesResultSchema>;
 export type ReadResourceRequest = z.infer<typeof ReadResourceRequestSchema>;
 export type ReadResourceResult = z.infer<typeof ReadResourceResultSchema>;
+export type ResourceReadResult = z.infer<typeof ResourceReadResultSchema>;

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -25,10 +25,35 @@ export const AudioContentSchema = z.object({
   _meta: z.record(z.string(), z.unknown()).optional(),
 });
 
+export const ResourceLinkContentSchema = z.object({
+  type: z.literal('resource_link'),
+  uri: z.string(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  mimeType: z.string().optional(),
+  annotations: z.record(z.string(), z.unknown()).optional(),
+  _meta: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const EmbeddedResourceContentSchema = z.object({
+  type: z.literal('resource'),
+  resource: z.object({
+    uri: z.string(),
+    title: z.string().optional(),
+    mimeType: z.string().optional(),
+    text: z.string().optional(),
+    blob: z.string().optional(),
+    annotations: z.record(z.string(), z.unknown()).optional(),
+  }),
+  _meta: z.record(z.string(), z.unknown()).optional(),
+});
+
 export const ContentBlockSchema = z.union([
   TextContentSchema,
   ImageContentSchema,
   AudioContentSchema,
+  ResourceLinkContentSchema,
+  EmbeddedResourceContentSchema,
 ]);
 
 export const JSONSchemaObjectSchema = z.object({
@@ -101,9 +126,13 @@ export const ToolListChangedNotificationSchema = z.object({
   params: z.object({}).optional(),
 });
 
+export const ToolCallResultSchema = CallToolResultSchema;
+
 export type TextContent = z.infer<typeof TextContentSchema>;
 export type ImageContent = z.infer<typeof ImageContentSchema>;
 export type AudioContent = z.infer<typeof AudioContentSchema>;
+export type ResourceLinkContent = z.infer<typeof ResourceLinkContentSchema>;
+export type EmbeddedResourceContent = z.infer<typeof EmbeddedResourceContentSchema>;
 export type ContentBlock = z.infer<typeof ContentBlockSchema>;
 export type JSONSchemaObject = z.infer<typeof JSONSchemaObjectSchema>;
 export type ToolAnnotations = z.infer<typeof ToolAnnotationsSchema>;
@@ -112,3 +141,4 @@ export type ListToolsRequest = z.infer<typeof ListToolsRequestSchema>;
 export type ListToolsResult = z.infer<typeof ListToolsResultSchema>;
 export type CallToolRequest = z.infer<typeof CallToolRequestSchema>;
 export type CallToolResult = z.infer<typeof CallToolResultSchema>;
+export type ToolCallResult = z.infer<typeof ToolCallResultSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface MCPMatcherImplementations {
   toBeSuccessful(this: unknown, received: unknown): Promise<MCPMatcherResult>;
   toHaveTextContent(this: unknown, received: unknown, expectedText: string): Promise<MCPMatcherResult>;
   toMatchTextContent(this: unknown, received: unknown, pattern: RegExp): Promise<MCPMatcherResult>;
+  toHaveResourceContent(this: unknown, received: unknown, uri: string): Promise<MCPMatcherResult>;
+  toHaveTextResource(this: unknown, received: unknown, expectedText: string): Promise<MCPMatcherResult>;
 }
 
 /** Matchers surfaced on the Assertion API once installed. */
@@ -59,4 +61,6 @@ export interface MCPMatchers {
   toBeSuccessful(): Promise<void>;
   toHaveTextContent(expectedText: string): Promise<void>;
   toMatchTextContent(pattern: RegExp): Promise<void>;
+  toHaveResourceContent(uri: string): Promise<void>;
+  toHaveTextResource(expectedText: string): Promise<void>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,9 @@ export interface MCPMatcherImplementations {
     received: unknown,
     resourceNames: string[]
   ): Promise<MCPMatcherResult>;
+  toBeSuccessful(this: unknown, received: unknown): Promise<MCPMatcherResult>;
+  toHaveTextContent(this: unknown, received: unknown, expectedText: string): Promise<MCPMatcherResult>;
+  toMatchTextContent(this: unknown, received: unknown, pattern: RegExp): Promise<MCPMatcherResult>;
 }
 
 /** Matchers surfaced on the Assertion API once installed. */
@@ -53,4 +56,7 @@ export interface MCPMatchers {
   toHaveTools(toolNames: string[]): Promise<void>;
   toHaveResource(resourceName: string): Promise<void>;
   toHaveResources(resourceNames: string[]): Promise<void>;
+  toBeSuccessful(): Promise<void>;
+  toHaveTextContent(expectedText: string): Promise<void>;
+  toMatchTextContent(pattern: RegExp): Promise<void>;
 }


### PR DESCRIPTION
## Summary

This PR improves support for tool call results by introducing a `ToolCallResult` class with helper methods and new matchers for validating tool results.

### Key Changes

1. **ToolCallResult Class** (`src/ToolCallResult.ts`)
   - Wraps tool call results with convenient helper methods
   - `.getTextContent()`: Extract text from first text content block
   - `.expectSuccess()`: Assert result is not an error (throws if `isError` is true)
   - `.getContentByType()`: Get all content blocks of a specific type
   - `.findContentByType()`: Find first content block of a specific type
   - Properties: `raw`, `content`, `structuredContent`, `isError`

2. **New Matchers**
   - `toBeSuccessful()`: Checks that result is not an error
   - `toHaveTextContent(expectedText)`: Validates exact text content match
   - `toMatchTextContent(pattern)`: Validates text content against regex

3. **Schema Validation**
   - `MCPStdinSubprocess.callTool()` now validates responses against `CallToolResultSchema`
   - Throws `ProtocolError` if response doesn't conform to schema
   - Returns `ToolCallResult` instance instead of raw response

4. **Extended Content Type Support**
   - Added `ResourceLinkContentSchema` for resource link content
   - Added `EmbeddedResourceContentSchema` for embedded resources
   - Full MCP protocol content type support

### Examples

```ts
// Using helper methods
const result = await app.callTool('read_file', { path: '/app/test.txt' });
const text = result.getTextContent(); // Returns text directly
result.expectSuccess(); // Throws if isError is true

// Using new matchers
await expect(result).toBeSuccessful();
await expect(result).toHaveTextContent('expected text');
await expect(result).toMatchTextContent(/regex pattern/);
```

### Breaking Change Note

`callTool()` now returns `ToolCallResult` instead of a raw object. However, `ToolCallResult` exposes a `content` property getter, so existing code like `result.content[0].text` continues to work without changes.

### Testing

- ✅ 19 new tests for `ToolCallResult` class
- ✅ 25 new tests for matchers (toBeSuccessful, toHaveTextContent, toMatchTextContent)
- ✅ All 179 tests passing
- ✅ Build successful

### Documentation

- Added `ToolCallResult.md` with complete API reference
- Updated `matchers.md` to include new tool result matchers
- Updated `callTool.md` to reflect new return type

## Test plan

- [x] Run build: `npm run build`
- [x] Run tests: `npm test`
- [x] All 179 tests pass
- [ ] CI checks pass (automated)